### PR TITLE
Fix parsing and rendering of the universal selector.

### DIFF
--- a/lib/css-selector-parser.js
+++ b/lib/css-selector-parser.js
@@ -337,6 +337,7 @@
         while (p < l) {
           c = str.charAt(p);
           if (c === '*') {
+            p++;
             (rule = rule || {}).tagName = '*';
           } else if (isIdentStart(c) || c === '\\') {
             (rule = rule || {}).tagName = getIdent();
@@ -546,7 +547,11 @@
             break;
           case 'rule':
             if (entity.tagName) {
-              res = _this.escapeIdentifier(entity.tagName);
+              if (entity.tagName === '*') {
+                res = '*';
+              } else {
+                res = _this.escapeIdentifier(entity.tagName);
+              }
             }
             if (entity.id) {
               res += "#" + (_this.escapeIdentifier(entity.id));

--- a/src/css-selector-parser.coffee
+++ b/src/css-selector-parser.coffee
@@ -240,6 +240,7 @@ class exports.CssSelectorParser
       while p < l
         c = str.charAt(p)
         if c == '*'
+          p++
           (rule = rule || {}).tagName = '*'
         else if isIdentStart(c) || c == '\\'
           (rule = rule || {}).tagName = getIdent()
@@ -395,7 +396,10 @@ class exports.CssSelectorParser
           res = entity.selectors.map(renderEntity).join ', '
         when 'rule'
           if entity.tagName
-            res = @escapeIdentifier(entity.tagName)
+            if entity.tagName == '*'
+              res = '*'
+            else
+              res = @escapeIdentifier(entity.tagName)
           if entity.id
             res += "##{@escapeIdentifier(entity.id)}"
           if entity.classNames

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -53,6 +53,10 @@ assertEquals 'tag1:has(.class)', parser.render(parser.parse('tag1:has(.class)'))
 assertEquals 'tag1:has(.class, .class2)', parser.render(parser.parse('tag1:has(.class,.class2)'))
 assertEquals 'tag1:has(.class:has(.subcls), .class2)', parser.render(parser.parse('tag1:has(.class:has(.subcls),.class2)'))
 
+assertEquals '*', parser.render(parser.parse('*'))
+assertEquals '*.class', parser.render(parser.parse('*.class'))
+assertEquals '* + *', parser.render(parser.parse('* + *'))
+
 assertError 'Expected ")" but end of file reached.', ->
   parser.parse(':has(.class')
 assertError 'Expected ")" but end of file reached.', ->


### PR DESCRIPTION
The universal selector was recognized during parsing, but the
character pointer was not advanced, resulting in infinite loop.
Added the missing increment.

When rendering, the universal selector was treated like other
special characters and escaped.  Added special case for it.

The tests didn't test for the universal selector, added few
cases to cover it.

Fixes #1 
