### PR TITLE
Add side effects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/mjs/index.js",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./dist/mjs/index.js",


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code with treeshake. Good for esm, modules, named imports.